### PR TITLE
feat: support auto-detect clock in/out

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ jobcan --help
 Usage: jobcan <COMMAND>
 
 Commands:
+  auto         Login to Jobcan and auto-detect clock in/out
   clock-in     Login to Jobcan and clock in
   clock-out    Login to Jobcan and clock out
   start-break  Login to Jobcan and start break

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,21 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum SubCommand {
+    #[clap(about = "Login to Jobcan and auto-detect clock in/out")]
+    Auto {
+        #[clap(flatten)]
+        credentials: Credentials,
+
+        #[clap(flatten)]
+        group_id: GroupID,
+
+        #[clap(flatten)]
+        night_shift: NightShift,
+
+        #[clap(flatten)]
+        note: Notes,
+    },
+
     #[clap(about = "Login to Jobcan and clock in")]
     ClockIn {
         #[clap(flatten)]

--- a/src/jobcan.rs
+++ b/src/jobcan.rs
@@ -183,7 +183,10 @@ impl Jobcan {
                 raw_error: e,
             })?;
 
-        if json == stamp_type.expected_response() {
+        if stamp_type
+            .expected_response()
+            .map_or(true, |expected| json == expected)
+        {
             Ok(())
         } else {
             Err(JobcanError::UnexpectedResponseError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,15 @@ async fn main() {
     let cli = cli::Cli::parse();
 
     match cli.sub_command {
+        cli::SubCommand::Auto {
+            credentials,
+            group_id,
+            night_shift,
+            note,
+            ..
+        } => {
+            run_stamp(credentials, group_id, night_shift, note, Stamp::Auto).await;
+        }
         cli::SubCommand::ClockIn {
             credentials,
             group_id,

--- a/src/stamp.rs
+++ b/src/stamp.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Stamp {
+    Auto,
     ClockIn,
     ClockOut,
     StartBreak,
@@ -12,46 +13,59 @@ pub enum Stamp {
 
 impl Display for Stamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Stamp::ClockIn => "ClockIn",
-            Stamp::ClockOut => "ClockOut",
-            Stamp::StartBreak => "StartBreak",
-            Stamp::EndBreak => "EndBreak",
-        };
-        write!(f, "{}", s)
+        write!(f, "{self:#?}")
     }
 }
 
 impl Stamp {
     pub fn to_request_params(&self) -> String {
         match self {
+            Stamp::Auto => "DEF".to_string(),
             Stamp::ClockIn => "work_start".to_string(),
             Stamp::ClockOut => "work_end".to_string(),
             Stamp::StartBreak => "rest_start".to_string(),
             Stamp::EndBreak => "rest_end".to_string(),
         }
     }
-    pub fn expected_response(&self) -> Response {
+    pub fn expected_response(&self) -> Option<Response> {
         // Note: Ignore `Response.result` and `Response.state`
         match self {
-            Stamp::ClockIn => Response {
-                current_status: "working".to_string(),
+            Stamp::Auto => None,
+            Stamp::ClockIn => Some(Response {
+                current_status: CurrentStatus::Working,
                 ..Default::default()
-            },
-            Stamp::ClockOut => Response {
-                current_status: "returned_home".to_string(),
+            }),
+            Stamp::ClockOut => Some(Response {
+                current_status: CurrentStatus::ReturnedHome,
                 ..Default::default()
-            },
-            Stamp::StartBreak => Response {
-                current_status: "resting".to_string(),
+            }),
+            Stamp::StartBreak => Some(Response {
+                current_status: CurrentStatus::Resting,
                 ..Default::default()
-            },
-            Stamp::EndBreak => Response {
-                current_status: "working".to_string(),
+            }),
+            Stamp::EndBreak => Some(Response {
+                current_status: CurrentStatus::Working,
                 ..Default::default()
-            },
+            }),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum IntOrString {
+    #[allow(dead_code)] // Note: Use json deserialization
+    Int(i32),
+    #[allow(dead_code)] // Note: Use json deserialization
+    Str(String),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum CurrentStatus {
+    Working,
+    ReturnedHome,
+    Resting,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,16 +73,16 @@ pub struct Response {
     #[allow(dead_code)] // Note: Use json deserialization
     result: i32,
     #[allow(dead_code)] // Note: Use json deserialization
-    state: i32,
-    current_status: String,
+    state: IntOrString,
+    current_status: CurrentStatus,
 }
 
 impl Default for Response {
     fn default() -> Self {
         Response {
             result: 0,
-            state: 0,
-            current_status: "".to_string(),
+            state: IntOrString::Int(0),
+            current_status: CurrentStatus::Working,
         }
     }
 }


### PR DESCRIPTION
大変便利に使わせていただいております。
自組織の都合で恐縮ですが、現在、打刻の【自動判別】機能を利用しており、これに対応するための変更を提案いたします。

## 実装内容

- 打刻における自動区分判別機能をサポート

## 参考資料

各種マイページでの打刻時・Web打刻時の区分判別について：
https://jobcan.zendesk.com/hc/ja/articles/201214519-%E5%90%84%E7%A8%AE%E3%83%9E%E3%82%A4%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%A7%E3%81%AE%E6%89%93%E5%88%BB%E6%99%82-Web%E6%89%93%E5%88%BB%E6%99%82%E3%81%AE%E5%8C%BA%E5%88%86%E5%88%A4%E5%88%A5

よろしくお願いします。
